### PR TITLE
Add ConnectionPoolSettings to use proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Akka Open Graph Fetcher
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.tyru/akka-open-graph-fetcher_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.tyru/akka-open-graph-fetcher_2.11/)
-[![Circle CI](https://img.shields.io/circleci/project/tyru/akka-open-graph-fetcher/master.svg)](https://circleci.com/gh/tyru/akka-open-graph-fetcher)
-[![Coverage Status](https://coveralls.io/repos/tyru/akka-open-graph-fetcher/badge.svg?branch=master&service=github)](https://coveralls.io/github/tyru/akka-open-graph-fetcher?branch=master)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.tkqubo/akka-open-graph-fetcher_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.tkqubo/akka-open-graph-fetcher_2.11/)
+[![Circle CI](https://img.shields.io/circleci/project/tkqubo/akka-open-graph-fetcher/master.svg)](https://circleci.com/gh/tkqubo/akka-open-graph-fetcher)
+[![Coverage Status](https://coveralls.io/repos/tkqubo/akka-open-graph-fetcher/badge.svg?branch=master&service=github)](https://coveralls.io/github/tkqubo/akka-open-graph-fetcher?branch=master)
 [![License: MIT](http://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## About
@@ -18,13 +18,13 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import com.github.tyru.akka_open_graph_fetcher._
+import com.github.oneteam_dev.akka_open_graph_fetcher._
 
 implicit val system = ActorSystem("console")
 implicit val mat = ActorMaterializer()
 
 val fetcher = OpenGraphFetcher()
-val future = fetcher.fetch("https://coveralls.io/github/tyru/akka-open-graph-fetcher?branch=master")
+val future = fetcher.fetch("https://coveralls.io/github/tkqubo/akka-open-graph-fetcher?branch=master")
 val openGraph = Await.result(future, Duration.Inf)
 
 println(openGraph.url)
@@ -33,7 +33,7 @@ println(openGraph.description)
 println(openGraph.image)
 println(openGraph.error)
 
-// https://coveralls.io/github/tyru/akka-open-graph-fetcher?branch=master
+// https://coveralls.io/github/tkqubo/akka-open-graph-fetcher?branch=master
 // Some(Coveralls.io - Test Coverage History and Statistics)
 // Some(The leading provider of test coverage analytics. Ensure that all your new code is fully covered, and see coverage trends emerge. Works with most CI services. Always free for open source.)
 // Some(/social.png)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Akka Open Graph Fetcher
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.tkqubo/akka-open-graph-fetcher_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.tkqubo/akka-open-graph-fetcher_2.11/)
-[![Circle CI](https://img.shields.io/circleci/project/tkqubo/akka-open-graph-fetcher/master.svg)](https://circleci.com/gh/tkqubo/akka-open-graph-fetcher)
-[![Coverage Status](https://coveralls.io/repos/tkqubo/akka-open-graph-fetcher/badge.svg?branch=master&service=github)](https://coveralls.io/github/tkqubo/akka-open-graph-fetcher?branch=master)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.tyru/akka-open-graph-fetcher_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.tyru/akka-open-graph-fetcher_2.11/)
+[![Circle CI](https://img.shields.io/circleci/project/tyru/akka-open-graph-fetcher/master.svg)](https://circleci.com/gh/tyru/akka-open-graph-fetcher)
+[![Coverage Status](https://coveralls.io/repos/tyru/akka-open-graph-fetcher/badge.svg?branch=master&service=github)](https://coveralls.io/github/tyru/akka-open-graph-fetcher?branch=master)
 [![License: MIT](http://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## About
@@ -18,13 +18,13 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 
-import com.github.tkqubo.akka_open_graph_fetcher._
+import com.github.tyru.akka_open_graph_fetcher._
 
 implicit val system = ActorSystem("console")
 implicit val mat = ActorMaterializer()
 
 val fetcher = OpenGraphFetcher()
-val future = fetcher.fetch("https://coveralls.io/github/tkqubo/akka-open-graph-fetcher?branch=master")
+val future = fetcher.fetch("https://coveralls.io/github/tyru/akka-open-graph-fetcher?branch=master")
 val openGraph = Await.result(future, Duration.Inf)
 
 println(openGraph.url)
@@ -33,7 +33,7 @@ println(openGraph.description)
 println(openGraph.image)
 println(openGraph.error)
 
-// https://coveralls.io/github/tkqubo/akka-open-graph-fetcher?branch=master
+// https://coveralls.io/github/tyru/akka-open-graph-fetcher?branch=master
 // Some(Coveralls.io - Test Coverage History and Statistics)
 // Some(The leading provider of test coverage analytics. Ensure that all your new code is fully covered, and see coverage trends emerge. Works with most CI services. Always free for open source.)
 // Some(/social.png)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Akka Open Graph Fetcher
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.github.tkqubo/akka-open-graph-fetcher_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.github.tkqubo/akka-open-graph-fetcher_2.11/)
-[![Circle CI](https://img.shields.io/circleci/project/tkqubo/akka-open-graph-fetcher/master.svg)](https://circleci.com/gh/tkqubo/akka-open-graph-fetcher)
-[![Coverage Status](https://coveralls.io/repos/tkqubo/akka-open-graph-fetcher/badge.svg?branch=master&service=github)](https://coveralls.io/github/tkqubo/akka-open-graph-fetcher?branch=master)
+[![Circle CI](https://img.shields.io/circleci/project/oneteam-dev/akka-open-graph-fetcher/master.svg)](https://circleci.com/gh/oneteam-dev/akka-open-graph-fetcher)
+[![Coverage Status](https://coveralls.io/repos/oneteam-dev/akka-open-graph-fetcher/badge.svg?branch=master&service=github)](https://coveralls.io/github/oneteam-dev/akka-open-graph-fetcher?branch=master)
 [![License: MIT](http://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
 ## About
@@ -24,7 +24,7 @@ implicit val system = ActorSystem("console")
 implicit val mat = ActorMaterializer()
 
 val fetcher = OpenGraphFetcher()
-val future = fetcher.fetch("https://coveralls.io/github/tkqubo/akka-open-graph-fetcher?branch=master")
+val future = fetcher.fetch("https://coveralls.io/github/oneteam-dev/akka-open-graph-fetcher?branch=master")
 val openGraph = Await.result(future, Duration.Inf)
 
 println(openGraph.url)
@@ -33,7 +33,7 @@ println(openGraph.description)
 println(openGraph.image)
 println(openGraph.error)
 
-// https://coveralls.io/github/tkqubo/akka-open-graph-fetcher?branch=master
+// https://coveralls.io/github/oneteam-dev/akka-open-graph-fetcher?branch=master
 // Some(Coveralls.io - Test Coverage History and Statistics)
 // Some(The leading provider of test coverage analytics. Ensure that all your new code is fully covered, and see coverage trends emerge. Works with most CI services. Always free for open source.)
 // Some(/social.png)

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-organization := "com.github.tkqubo"
+organization := "com.github.tyru"
 
 name := "akka-open-graph-fetcher"
 
@@ -11,14 +11,14 @@ javaOptions in Test ++= Seq(
   s"-Djava.util.Arrays.useLegacyMergeSort=true"
 )
 
-initialCommands := "import com.github.tkqubo.akka_open_graph_fetcher._"
+initialCommands := "import com.github.tyru.akka_open_graph_fetcher._"
 
 // sbt publish
 publishArtifact in Test := false
 publishMavenStyle := true
 pomIncludeRepository := { _ => false }
 pomExtra := (
-  <url>https://github.com/tkqubo/akka-open-graph-fetcher</url>
+  <url>https://github.com/tyru/akka-open-graph-fetcher</url>
     <licenses>
       <license>
         <name>MIT</name>
@@ -26,15 +26,15 @@ pomExtra := (
       </license>
     </licenses>
     <scm>
-      <url>git@github.com:tkqubo/akka-open-graph-fetcher.git</url>
-      <connection>scm:git:github.com/tkqubo/akka-open-graph-fetcher.git</connection>
-      <developerConnection>scm:git:git@github.com:tkqubo/akka-open-graph-fetcher.git</developerConnection>
+      <url>git@github.com:tyru/akka-open-graph-fetcher.git</url>
+      <connection>scm:git:github.com/tyru/akka-open-graph-fetcher.git</connection>
+      <developerConnection>scm:git:git@github.com:tyru/akka-open-graph-fetcher.git</developerConnection>
     </scm>
     <developers>
       <developer>
-        <id>tkqubo</id>
+        <id>tyru</id>
         <name>Takaichi Kubo</name>
-        <url>https://github.com/tkqubo</url>
+        <url>https://github.com/tyru</url>
       </developer>
     </developers>
   )
@@ -56,4 +56,4 @@ releasePublishArtifactsAction := PgpKeys.publishSigned.value
 site.settings
 site.includeScaladoc()
 ghpages.settings
-git.remoteRepo := "git@github.com:tkqubo/akka-open-graph-fetcher.git"
+git.remoteRepo := "git@github.com:tyru/akka-open-graph-fetcher.git"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-organization := "com.github.tyru"
+organization := "com.github.oneteam_dev"
 
 name := "akka-open-graph-fetcher"
 
@@ -11,7 +11,7 @@ javaOptions in Test ++= Seq(
   s"-Djava.util.Arrays.useLegacyMergeSort=true"
 )
 
-initialCommands := "import com.github.tyru.akka_open_graph_fetcher._"
+initialCommands := "import com.github.oneteam_dev.akka_open_graph_fetcher._"
 
 // sbt publish
 publishArtifact in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ publishArtifact in Test := false
 publishMavenStyle := true
 pomIncludeRepository := { _ => false }
 pomExtra := (
-  <url>https://github.com/tyru/akka-open-graph-fetcher</url>
+  <url>https://github.com/oneteam-dev/akka-open-graph-fetcher</url>
     <licenses>
       <license>
         <name>MIT</name>
@@ -26,15 +26,15 @@ pomExtra := (
       </license>
     </licenses>
     <scm>
-      <url>git@github.com:tyru/akka-open-graph-fetcher.git</url>
-      <connection>scm:git:github.com/tyru/akka-open-graph-fetcher.git</connection>
-      <developerConnection>scm:git:git@github.com:tyru/akka-open-graph-fetcher.git</developerConnection>
+      <url>git@github.com:oneteam-dev/akka-open-graph-fetcher.git</url>
+      <connection>scm:git:github.com/oneteam-dev/akka-open-graph-fetcher.git</connection>
+      <developerConnection>scm:git:git@github.com:oneteam-dev/akka-open-graph-fetcher.git</developerConnection>
     </scm>
     <developers>
       <developer>
-        <id>tyru</id>
-        <name>Takaichi Kubo</name>
-        <url>https://github.com/tyru</url>
+        <id>oneteam-dev</id>
+        <name>Oneteam Dev</name>
+        <url>https://github.com/oneteam-dev</url>
       </developer>
     </developers>
   )
@@ -56,4 +56,4 @@ releasePublishArtifactsAction := PgpKeys.publishSigned.value
 site.settings
 site.includeScaladoc()
 ghpages.settings
-git.remoteRepo := "git@github.com:tyru/akka-open-graph-fetcher.git"
+git.remoteRepo := "git@github.com:oneteam-dev/akka-open-graph-fetcher.git"

--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,6 @@ deployment:
     commands:
       - sbt doc
       - sbt coverageReport
-      - git config --global user.email "tk.qubo@gmail.com"
-      - git config --global user.name "tyru"
+      - git config --global user.email "oneteam-dev@teamwork.motivation-cloudapp.com"
+      - git config --global user.name "oneteam-dev"
       - sbt ghpages-push-site

--- a/circle.yml
+++ b/circle.yml
@@ -28,5 +28,5 @@ deployment:
       - sbt doc
       - sbt coverageReport
       - git config --global user.email "tk.qubo@gmail.com"
-      - git config --global user.name "tkqubo"
+      - git config --global user.name "tyru"
       - sbt ghpages-push-site

--- a/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/Error.scala
+++ b/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/Error.scala
@@ -1,4 +1,4 @@
-package com.github.tkqubo.akka_open_graph_fetcher
+package com.github.tyru.akka_open_graph_fetcher
 
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import spray.json.DefaultJsonProtocol._

--- a/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/Error.scala
+++ b/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/Error.scala
@@ -1,4 +1,4 @@
-package com.github.tyru.akka_open_graph_fetcher
+package com.github.oneteam_dev.akka_open_graph_fetcher
 
 import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import spray.json.DefaultJsonProtocol._

--- a/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraph.scala
+++ b/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraph.scala
@@ -1,4 +1,4 @@
-package com.github.tkqubo.akka_open_graph_fetcher
+package com.github.tyru.akka_open_graph_fetcher
 
 import spray.json.DefaultJsonProtocol._
 import spray.json._

--- a/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraph.scala
+++ b/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraph.scala
@@ -1,4 +1,4 @@
-package com.github.tyru.akka_open_graph_fetcher
+package com.github.oneteam_dev.akka_open_graph_fetcher
 
 import spray.json.DefaultJsonProtocol._
 import spray.json._

--- a/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphFetcher.scala
+++ b/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphFetcher.scala
@@ -1,4 +1,4 @@
-package com.github.tkqubo.akka_open_graph_fetcher
+package com.github.tyru.akka_open_graph_fetcher
 
 import java.net.{URI, URISyntaxException}
 
@@ -9,8 +9,8 @@ import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.http.scaladsl.{Http, HttpExt}
 import akka.pattern.after
 import akka.stream.ActorMaterializer
-import com.github.tkqubo.akka_open_graph_fetcher
-import com.github.tkqubo.akka_open_graph_fetcher.OpenGraphFetcher._
+import com.github.tyru.akka_open_graph_fetcher
+import com.github.tyru.akka_open_graph_fetcher.OpenGraphFetcher._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}

--- a/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphFetcher.scala
+++ b/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphFetcher.scala
@@ -1,4 +1,4 @@
-package com.github.tyru.akka_open_graph_fetcher
+package com.github.oneteam_dev.akka_open_graph_fetcher
 
 import java.net.{URI, URISyntaxException}
 
@@ -9,8 +9,8 @@ import akka.http.scaladsl.settings.ConnectionPoolSettings
 import akka.http.scaladsl.{Http, HttpExt}
 import akka.pattern.after
 import akka.stream.ActorMaterializer
-import com.github.tyru.akka_open_graph_fetcher
-import com.github.tyru.akka_open_graph_fetcher.OpenGraphFetcher._
+import com.github.oneteam_dev.akka_open_graph_fetcher
+import com.github.oneteam_dev.akka_open_graph_fetcher.OpenGraphFetcher._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future, TimeoutException}

--- a/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphParser.scala
+++ b/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphParser.scala
@@ -1,4 +1,4 @@
-package com.github.tkqubo.akka_open_graph_fetcher
+package com.github.tyru.akka_open_graph_fetcher
 
 import java.nio.charset.Charset
 import java.util

--- a/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphParser.scala
+++ b/src/main/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphParser.scala
@@ -1,4 +1,4 @@
-package com.github.tyru.akka_open_graph_fetcher
+package com.github.oneteam_dev.akka_open_graph_fetcher
 
 import java.nio.charset.Charset
 import java.util

--- a/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/ErrorTest.scala
+++ b/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/ErrorTest.scala
@@ -1,4 +1,4 @@
-package com.github.tkqubo.akka_open_graph_fetcher
+package com.github.tyru.akka_open_graph_fetcher
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes.ClientError
@@ -11,7 +11,7 @@ import scala.concurrent.TimeoutException
 /**
   * Test class for [[Error]]
   * {{{
-  * sbt "test-only com.github.tkqubo.akka_http_og_fetcher.ErrorTest"
+  * sbt "test-only com.github.tyru.akka_http_og_fetcher.ErrorTest"
   * }}}
   */
 // scalastyle:off magic.number

--- a/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/ErrorTest.scala
+++ b/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/ErrorTest.scala
@@ -1,4 +1,4 @@
-package com.github.tyru.akka_open_graph_fetcher
+package com.github.oneteam_dev.akka_open_graph_fetcher
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes.ClientError
@@ -11,7 +11,7 @@ import scala.concurrent.TimeoutException
 /**
   * Test class for [[Error]]
   * {{{
-  * sbt "test-only com.github.tyru.akka_http_og_fetcher.ErrorTest"
+  * sbt "test-only com.github.oneteam_dev.akka_http_og_fetcher.ErrorTest"
   * }}}
   */
 // scalastyle:off magic.number

--- a/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphFetcherTest.scala
+++ b/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphFetcherTest.scala
@@ -1,4 +1,4 @@
-package com.github.tkqubo.akka_open_graph_fetcher
+package com.github.tyru.akka_open_graph_fetcher
 
 
 import java.net.URISyntaxException
@@ -22,7 +22,7 @@ import scalaz.syntax.std.all._
 /**
   * Test class for [[OpenGraphFetcher]]
   * {{{
-  * sbt "test-only com.github.tkqubo.akka_open_graph_fetcher.OpenGraphFetcherTest"
+  * sbt "test-only com.github.tyru.akka_open_graph_fetcher.OpenGraphFetcherTest"
   * }}}
   */
 // scalastyle:off magic.number

--- a/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphFetcherTest.scala
+++ b/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphFetcherTest.scala
@@ -1,4 +1,4 @@
-package com.github.tyru.akka_open_graph_fetcher
+package com.github.oneteam_dev.akka_open_graph_fetcher
 
 
 import java.net.URISyntaxException
@@ -22,7 +22,7 @@ import scalaz.syntax.std.all._
 /**
   * Test class for [[OpenGraphFetcher]]
   * {{{
-  * sbt "test-only com.github.tyru.akka_open_graph_fetcher.OpenGraphFetcherTest"
+  * sbt "test-only com.github.oneteam_dev.akka_open_graph_fetcher.OpenGraphFetcherTest"
   * }}}
   */
 // scalastyle:off magic.number

--- a/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphParserTest.scala
+++ b/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphParserTest.scala
@@ -1,4 +1,4 @@
-package com.github.tkqubo.akka_open_graph_fetcher
+package com.github.tyru.akka_open_graph_fetcher
 
 import java.nio.charset.Charset
 
@@ -23,7 +23,7 @@ import scalaz.syntax.std.all._
 /**
   * Test class for [[OpenGraphParser]]
   * {{{
-  * sbt "test-only com.github.tkqubo.akka_open_graph_fetcher.OpenGraphParserTest"
+  * sbt "test-only com.github.tyru.akka_open_graph_fetcher.OpenGraphParserTest"
   * }}}
   */
 // scalastyle:off magic.number

--- a/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphParserTest.scala
+++ b/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphParserTest.scala
@@ -1,4 +1,4 @@
-package com.github.tyru.akka_open_graph_fetcher
+package com.github.oneteam_dev.akka_open_graph_fetcher
 
 import java.nio.charset.Charset
 
@@ -23,7 +23,7 @@ import scalaz.syntax.std.all._
 /**
   * Test class for [[OpenGraphParser]]
   * {{{
-  * sbt "test-only com.github.tyru.akka_open_graph_fetcher.OpenGraphParserTest"
+  * sbt "test-only com.github.oneteam_dev.akka_open_graph_fetcher.OpenGraphParserTest"
   * }}}
   */
 // scalastyle:off magic.number

--- a/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphTest.scala
+++ b/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphTest.scala
@@ -1,4 +1,4 @@
-package com.github.tyru.akka_open_graph_fetcher
+package com.github.oneteam_dev.akka_open_graph_fetcher
 
 import org.specs2.mutable.Specification
 import spray.json.DefaultJsonProtocol._
@@ -7,7 +7,7 @@ import spray.json._
 /**
   * Test class for [[OpenGraph]]
   * {{{
-  * sbt "test-only com.github.tyru.akka_http_og_fetcher.OpenGraphTest"
+  * sbt "test-only com.github.oneteam_dev.akka_http_og_fetcher.OpenGraphTest"
   * }}}
   */
 // scalastyle:off magic.number

--- a/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphTest.scala
+++ b/src/test/scala/com/github/tkqubo/akka_open_graph_fetcher/OpenGraphTest.scala
@@ -1,4 +1,4 @@
-package com.github.tkqubo.akka_open_graph_fetcher
+package com.github.tyru.akka_open_graph_fetcher
 
 import org.specs2.mutable.Specification
 import spray.json.DefaultJsonProtocol._
@@ -7,7 +7,7 @@ import spray.json._
 /**
   * Test class for [[OpenGraph]]
   * {{{
-  * sbt "test-only com.github.tkqubo.akka_http_og_fetcher.OpenGraphTest"
+  * sbt "test-only com.github.tyru.akka_http_og_fetcher.OpenGraphTest"
   * }}}
   */
 // scalastyle:off magic.number


### PR DESCRIPTION
* c40fba17ee1bb1d70e5de42826b9a3a48ed2ce06: これが現在 comuque-api の master で使われているバージョンです
* 32c0c2ddc8df65a7f1270f4f12a357d091d70d69, 61618e01346cf1b3e854b85d72c9c1ae9c8ead99: 今回名前空間を oneteam-dev のものに変えました

* 基本的に `tyru`, `tkqubo` といった記述はなくしたつもりです
    * README の Maven Central は（上げてないので）tkqubo さんの URL のままにしました

## TODO

* マージ後、comuque-api の .jar も更新する
* 今後ブランチの運用をどうするか 
  * とりあえず master は tkqubo/akka-open-graph-fetcher のままで oneteam-master ブランチを作ってそこを更新していくとか
  * とりあえず master と同じ oneteam-master を作って本 PR はそこに向けました

## （必須でない）細かい TODO

* 今後バージョン番号の運用をどうするか
* CI は設定していないので動いていないがどうするか

## 関連

https://github.com/oneteam-dev/comuque-api/pull/4721